### PR TITLE
Add: ユーザーと登録商品の紐付け

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
+  before_action :require_login
+
+  private
+
+  def not_authenticated
+    flash[:warning] = t('defaults.message.not_authenticated')
+    redirect_to login_path
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   def index
-    @products = Product.all.includes(:user).order(created_at: :desc)
+    @products = Product.where(user_id: current_user.id).includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login, only: %i[top]
+
   def top; end
 end
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new
     @user = User.new
   end
@@ -6,7 +8,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path, notice: t('.login_success')
+      redirect_back_or_to products_path, notice: t('.login_success')
     else
       flash.now[:alert] = t('.login_failed')
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new
     @user = User.new
   end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,9 +2,26 @@
   <nav class="navbar navbar-expand-lg navigation navbar-light bg-light">
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ml-auto main-nav align-items-center">
-        <li class="nav-item">
-          <%= link_to t('defaults.login'), login_path ,class: 'nav-link' %>
-        </li>
+        <div class="me-1">
+          <li class="btn btn-outline-danger", "mr-3">
+            <%= link_to 'TOPへ', root_path, class: 'dropdown-item' %>
+          </li>
+        </div>
+      </ul>
+    </div>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav ms-auto main-nav align-items-center">
+        <div class="me-1">
+          <li class="btn btn-outline-primary">
+            <%= link_to t('defaults.login'), login_path, class: 'dropdown-item' %>
+          </li>
+        </div>
+        <div class="me-1">
+          <li class="btn btn-outline-primary">
+            <%= link_to t('defaults.signup'), new_user_path, class: 'dropdown-item' %>
+          </li>
+        </div>
       </ul>
     </div>
   </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,12 +6,17 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav ms-auto main-nav align-items-center">
+      <ul class="navbar-nav ml-auto main-nav align-items-center">
         <div class="me-1">
           <li class="btn btn-outline-danger", "mr-3">
             <%= link_to 'TOPへ', root_path, class: 'dropdown-item' %>
           </li>
         </div>
+      </ul>
+    </div>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav ms-auto main-nav align-items-center">
 
         <div class="me-1">
           <li class="btn btn-outline-primary">


### PR DESCRIPTION
### 内容
- ログインしているユーザーが登録した商品のみ、一覧で確認できるよう変更しました。
products_controller.rb
`@products = Product.all.includes(:user).order(created_at: :desc)`
　　　　　　　　　　　　　↓　変更
`@products = Product.where(user_id: current_user.id).includes(:user).order(created_at: :desc)`

- ログイン時、一覧画面へ遷移するよう変更しました。
- ログインしていない場合、一覧ページに飛ぼうとすると、ログイン画面へ遷移するようにしました。

### 確認
- ユーザーA
<img width="1277" alt="c025bf8a00bc1d9400306b104a53053d" src="https://user-images.githubusercontent.com/101347928/212840726-0bab1397-01fe-47e6-87ca-255edd707666.png">

<img width="1399" alt="7d1e42df221cf1d1ec9c491fcb7f41e0" src="https://user-images.githubusercontent.com/101347928/212840286-da60b304-e755-4e2b-b32b-5fce9d1b05be.png">

- ユーザーB
<img width="1333" alt="f66341cbc42e4e7ffeb6dcfe28bede95" src="https://user-images.githubusercontent.com/101347928/212841003-e49199c6-7b47-4049-8e1b-068730724b5e.png">

<img width="1436" alt="c484b8dd2e69a08b826640988d6a84e2" src="https://user-images.githubusercontent.com/101347928/212841272-45c2fd86-1ebc-4381-aeea-43abf211af6b.png">

- ログインしてない場合
<img width="1295" alt="0a166c291e5f30d256f59b9fed9da926" src="https://user-images.githubusercontent.com/101347928/212840454-0ffab393-a942-4780-9b05-dc78cab7080b.png">

