### PR TITLE
Fix: skip_before_actionの項目変更

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -177,3 +177,16 @@ input[name="tab_item"] {
   display: inline-block;
   text-align: left;
 }
+
+.new_user_back {
+  color: #2b546a;
+}
+
+.new_user_back:hover {
+  text-decoration: none;
+  color: #2b546a;
+}
+
+.text_container {
+  text-align: center;
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, only: %i[top]
+  skip_before_action :require_login, only: %i[top terms_of_service privacy_policy]
 
   def top; end
   def privacy_policy; end

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -69,4 +69,7 @@
     </div>
   </div>
   <p class="text-right mt-5">以上</p>
+  <div class="text_container">
+    <%= link_to t('.new_user'), new_user_path, class: "new_user_back" %>
+  </div>
 </div>

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -144,4 +144,7 @@
     </div>
   </div>
   <p class="text-right mt-5">以上</p>
+  <div class="text_container">
+    <%= link_to t('.new_user'), new_user_path, class: "new_user_back" %>
+  </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -62,5 +62,9 @@ ja:
       clear: 'クリア'
       min: '以上'
       max: '以下'
-
+  static_pages:
+    terms_of_service:
+      new_user: '登録ページへ'
+    privacy_policy:
+      new_user: '登録ページへ'
 


### PR DESCRIPTION
### 内容
- 未ログイン時に利用規約、プライバシーポリシーが見られなかったので、skip_before_actionに項目を追加し、見られるよう変更しました。
- 利用規約、プライバシーポリシーから登録ページへ戻れるようリンクを追加しました。